### PR TITLE
Fix device mismatch during scatter of allReduce.

### DIFF
--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -1061,7 +1061,7 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
                 const size_t j_src = j_src_0 == 0 ? j_dst : (j_src_0 - (j_src_0 <= j_dst ? 1 : 0));
                 auto & bcj_src = backend_ctx->backend_configs[j_src];
 
-                ggml_backend_tensor_copy_async(bcj_dst.backend, bcj_src.backend, dst_views[j_dst*n_backends], src_views[j_dst*n_backends + j_src]);
+                ggml_backend_tensor_copy_async(bcj_dst.backend, bcj_src.backend, dst_views[j_dst*n_backends], src_views[j_dst*n_backends + j_src_0]);
             }
         }
         return GGML_STATUS_SUCCESS;


### PR DESCRIPTION
There is a mismatch between the dst buffer device and the backend device, causing the use of sync copies

