### PR TITLE
review : pr/19378 (backend agnostic tensor parallelism)

### DIFF
--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -274,8 +274,6 @@ extern "C" {
     GGML_API ggml_backend_dev_t ggml_backend_dev_by_name(const char * name);
     GGML_API ggml_backend_dev_t ggml_backend_dev_by_type(enum ggml_backend_dev_type type);
 
-    GGML_API bool ggml_backend_dev_is_meta(ggml_backend_dev_t dev);
-
     // Direct backend (stream) initialization
     // = ggml_backend_dev_init(ggml_backend_dev_by_name(name), params)
     GGML_API ggml_backend_t ggml_backend_init_by_name(const char * name, const char * params);

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -247,33 +247,13 @@ extern "C" {
     };
 
     // function to assign split states for statically allocated tensors, compute tensor split states will be assigned to be compatible:
-    typedef struct ggml_backend_meta_split_state (*ggml_backend_meta_get_split_state_t)(const struct ggml_tensor * tensor, void * userdata);
-
-    GGML_API bool ggml_backend_dev_is_meta(ggml_backend_dev_t dev);
-    GGML_API size_t ggml_backend_meta_dev_n_devs(ggml_backend_dev_t meta_dev);
-    GGML_API ggml_backend_dev_t ggml_backend_meta_dev_simple_dev(ggml_backend_dev_t meta_dev, size_t index);
+    typedef struct ggml_backend_meta_split_state(*ggml_backend_meta_get_split_state_t)(const struct ggml_tensor * tensor, void * userdata);
 
     // create a new meta device from "simple" devices, meta buffer type/buffer/backend is then derived from this:
+    // TODO: this looks a bit strange - a backend API creates a device. I think we should try
+    //       express this as a backend registry functionality instead
     GGML_API ggml_backend_dev_t ggml_backend_meta_device(
         ggml_backend_dev_t * devs, size_t n_devs, ggml_backend_meta_get_split_state_t get_split_state, void * get_split_state_ud);
-
-    GGML_API bool ggml_backend_buft_is_meta(ggml_backend_buffer_type_t buft);
-    GGML_API size_t ggml_backend_meta_buft_n_bufts(ggml_backend_buffer_type_t meta_buft);
-    GGML_API ggml_backend_buffer_type_t ggml_backend_meta_buft_simple_buft(ggml_backend_buffer_type_t meta_buft, size_t index);
-
-    GGML_API bool ggml_backend_buffer_is_meta(ggml_backend_buffer_t buf);
-    GGML_API size_t ggml_backend_meta_buffer_n_bufs(ggml_backend_buffer_t meta_buf);
-    GGML_API ggml_backend_buffer_t ggml_backend_meta_buffer_simple_buffer(ggml_backend_buffer_t meta_buf, size_t index);
-    GGML_API struct ggml_tensor * ggml_backend_meta_buffer_simple_tensor(const struct ggml_tensor * tensor, size_t index);
-
-    GGML_API bool ggml_backend_is_meta(ggml_backend_t backend);
-    GGML_API size_t ggml_backend_meta_n_backends(ggml_backend_t meta_backend);
-    GGML_API ggml_backend_t ggml_backend_meta_simple_backend(ggml_backend_t meta_backend, size_t index);
-
-    GGML_API struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(const struct ggml_tensor * tensor, bool assume_sync);
-
-    // temporary workaround to statically allocate tensors from a context in a deduplicated way:
-    GGML_API struct ggml_backend_buffer * ggml_backend_meta_alloc_ctx_tensors_from_buft(struct ggml_context * ctx, ggml_backend_buffer_type_t buft);
 
     //
     // Backend registry
@@ -293,6 +273,8 @@ extern "C" {
     GGML_API ggml_backend_dev_t ggml_backend_dev_get(size_t index);
     GGML_API ggml_backend_dev_t ggml_backend_dev_by_name(const char * name);
     GGML_API ggml_backend_dev_t ggml_backend_dev_by_type(enum ggml_backend_dev_type type);
+
+    GGML_API bool ggml_backend_dev_is_meta(ggml_backend_dev_t dev);
 
     // Direct backend (stream) initialization
     // = ggml_backend_dev_init(ggml_backend_dev_by_name(name), params)

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -220,42 +220,6 @@ extern "C" {
     typedef struct ggml_backend_feature * (*ggml_backend_get_features_t)(ggml_backend_reg_t reg);
 
     //
-    // Meta backend
-    //
-
-    #define GGML_BACKEND_META_MAX_DEVICES 16
-
-    enum ggml_backend_meta_split_axis {
-        // tensor split by tensor dimensions:
-        GGML_BACKEND_SPLIT_AXIS_0   =  0,
-        GGML_BACKEND_SPLIT_AXIS_1   =  1,
-        GGML_BACKEND_SPLIT_AXIS_2   =  2,
-        GGML_BACKEND_SPLIT_AXIS_3   =  3,
-
-        GGML_BACKEND_SPLIT_AXIS_MIRRORED = 10, // all values on all backends
-        GGML_BACKEND_SPLIT_AXIS_PARTIAL  = 11, // each backend has a partial sum
-
-        // for internal bookkeeping only:
-        GGML_BACKEND_SPLIT_AXIS_NONE     = 98,
-        GGML_BACKEND_SPLIT_AXIS_UNKNOWN  = 99,
-    };
-    GGML_API const char * ggml_backend_meta_split_axis_name(enum ggml_backend_meta_split_axis split_axis);
-
-    struct ggml_backend_meta_split_state {
-        enum ggml_backend_meta_split_axis axis;
-        int64_t                           ne[GGML_BACKEND_META_MAX_DEVICES];
-    };
-
-    // function to assign split states for statically allocated tensors, compute tensor split states will be assigned to be compatible:
-    typedef struct ggml_backend_meta_split_state(*ggml_backend_meta_get_split_state_t)(const struct ggml_tensor * tensor, void * userdata);
-
-    // create a new meta device from "simple" devices, meta buffer type/buffer/backend is then derived from this:
-    // TODO: this looks a bit strange - a backend API creates a device. I think we should try
-    //       express this as a backend registry functionality instead
-    GGML_API ggml_backend_dev_t ggml_backend_meta_device(
-        ggml_backend_dev_t * devs, size_t n_devs, ggml_backend_meta_get_split_state_t get_split_state, void * get_split_state_ud);
-
-    //
     // Backend registry
     //
 

--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -1236,6 +1236,9 @@ size_t ggml_backend_alloc_ctx_tensors_from_buft_size(struct ggml_context * ctx, 
 
 ggml_backend_buffer_t ggml_backend_alloc_ctx_tensors_from_buft(struct ggml_context * ctx, ggml_backend_buffer_type_t buft) {
     size_t nbytes_total = 0;
+    if (ggml_backend_buft_is_meta(buft)) {
+        return ggml_backend_meta_alloc_ctx_tensors_from_buft(ctx, buft);
+    }
     return ggml_backend_alloc_ctx_tensors_from_buft_impl(ctx, buft, &nbytes_total, /*no_alloc =*/ false);
 }
 

--- a/ggml/src/ggml-backend-impl.h
+++ b/ggml/src/ggml-backend-impl.h
@@ -87,6 +87,32 @@ extern "C" {
     GGML_API void                  ggml_backend_multi_buffer_set_usage(ggml_backend_buffer_t buffer, enum ggml_backend_buffer_usage usage);
 
     //
+    // Backend (meta)
+    //
+
+    GGML_API size_t ggml_backend_meta_dev_n_devs(ggml_backend_dev_t meta_dev);
+    GGML_API ggml_backend_dev_t ggml_backend_meta_dev_simple_dev(ggml_backend_dev_t meta_dev, size_t index);
+
+    GGML_API bool ggml_backend_buft_is_meta(ggml_backend_buffer_type_t buft);
+    GGML_API size_t ggml_backend_meta_buft_n_bufts(ggml_backend_buffer_type_t meta_buft);
+    GGML_API ggml_backend_buffer_type_t ggml_backend_meta_buft_simple_buft(ggml_backend_buffer_type_t meta_buft, size_t index);
+
+    GGML_API bool ggml_backend_buffer_is_meta(ggml_backend_buffer_t buf);
+    GGML_API size_t ggml_backend_meta_buffer_n_bufs(ggml_backend_buffer_t meta_buf);
+    GGML_API ggml_backend_buffer_t ggml_backend_meta_buffer_simple_buffer(ggml_backend_buffer_t meta_buf, size_t index);
+    GGML_API struct ggml_tensor * ggml_backend_meta_buffer_simple_tensor(const struct ggml_tensor * tensor, size_t index);
+
+    GGML_API bool ggml_backend_is_meta(ggml_backend_t backend);
+    GGML_API size_t ggml_backend_meta_n_backends(ggml_backend_t meta_backend);
+    GGML_API ggml_backend_t ggml_backend_meta_simple_backend(ggml_backend_t meta_backend, size_t index);
+
+    GGML_API struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(const struct ggml_tensor * tensor, bool assume_sync);
+
+    // temporary workaround to statically allocate tensors from a context in a deduplicated way:
+    GGML_API struct ggml_backend_buffer * ggml_backend_meta_alloc_ctx_tensors_from_buft(struct ggml_context * ctx, ggml_backend_buffer_type_t buft);
+
+
+    //
     // Backend (stream)
     //
 

--- a/ggml/src/ggml-backend-impl.h
+++ b/ggml/src/ggml-backend-impl.h
@@ -2,9 +2,7 @@
 
 // ggml-backend internal header
 
-#include "ggml-alloc.h"
 #include "ggml-backend.h"
-#include "ggml.h"
 
 #ifdef  __cplusplus
 extern "C" {

--- a/ggml/src/ggml-backend-impl.h
+++ b/ggml/src/ggml-backend-impl.h
@@ -90,27 +90,15 @@ extern "C" {
     // Backend (meta)
     //
 
-    GGML_API size_t ggml_backend_meta_dev_n_devs(ggml_backend_dev_t meta_dev);
-    GGML_API ggml_backend_dev_t ggml_backend_meta_dev_simple_dev(ggml_backend_dev_t meta_dev, size_t index);
-
-    GGML_API bool ggml_backend_buft_is_meta(ggml_backend_buffer_type_t buft);
-    GGML_API size_t ggml_backend_meta_buft_n_bufts(ggml_backend_buffer_type_t meta_buft);
-    GGML_API ggml_backend_buffer_type_t ggml_backend_meta_buft_simple_buft(ggml_backend_buffer_type_t meta_buft, size_t index);
-
+    GGML_API bool ggml_backend_is_meta       (ggml_backend_t backend);
     GGML_API bool ggml_backend_buffer_is_meta(ggml_backend_buffer_t buf);
-    GGML_API size_t ggml_backend_meta_buffer_n_bufs(ggml_backend_buffer_t meta_buf);
-    GGML_API ggml_backend_buffer_t ggml_backend_meta_buffer_simple_buffer(ggml_backend_buffer_t meta_buf, size_t index);
-    GGML_API struct ggml_tensor * ggml_backend_meta_buffer_simple_tensor(const struct ggml_tensor * tensor, size_t index);
+    GGML_API bool ggml_backend_buft_is_meta  (ggml_backend_buffer_type_t buft);
 
-    GGML_API bool ggml_backend_is_meta(ggml_backend_t backend);
-    GGML_API size_t ggml_backend_meta_n_backends(ggml_backend_t meta_backend);
+    GGML_API size_t         ggml_backend_meta_n_backends    (ggml_backend_t meta_backend);
     GGML_API ggml_backend_t ggml_backend_meta_simple_backend(ggml_backend_t meta_backend, size_t index);
-
-    GGML_API struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(const struct ggml_tensor * tensor, bool assume_sync);
 
     // temporary workaround to statically allocate tensors from a context in a deduplicated way:
     GGML_API struct ggml_backend_buffer * ggml_backend_meta_alloc_ctx_tensors_from_buft(struct ggml_context * ctx, ggml_backend_buffer_type_t buft);
-
 
     //
     // Backend (stream)

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -79,6 +79,8 @@ struct ggml_backend_meta_device_context {
     }
 };
 
+static bool ggml_backend_dev_is_meta(ggml_backend_dev_t dev);
+
 static const char * ggml_backend_meta_device_get_name(ggml_backend_dev_t dev) {
     GGML_ASSERT(ggml_backend_dev_is_meta(dev));
     const ggml_backend_meta_device_context * meta_dev_ctx = (const ggml_backend_meta_device_context *) dev->context;
@@ -188,7 +190,7 @@ static const ggml_backend_device_i ggml_backend_meta_device_iface = {
     /* .event_synchronize    = */ nullptr,
 };
 
-bool ggml_backend_dev_is_meta(ggml_backend_dev_t dev) {
+static bool ggml_backend_dev_is_meta(ggml_backend_dev_t dev) {
     return dev != nullptr && dev->iface.get_name == ggml_backend_meta_device_iface.get_name;
 }
 

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -5,6 +5,9 @@
 #include "ggml-alloc.h"
 #include "ggml-cpp.h"
 
+// TODO: tmp
+#include "ggml-ext.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cmath>

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -542,7 +542,7 @@ static void ggml_backend_meta_buffer_set_tensor(ggml_backend_buffer_t buffer, gg
         } break;
         default: {
             GGML_ABORT("fatal error");
-        } break;
+        }
     }
 }
 
@@ -579,7 +579,7 @@ static void ggml_backend_meta_buffer_get_tensor(ggml_backend_buffer_t buffer, co
         } break;
         default: {
             GGML_ABORT("fatal error");
-        } break;
+        }
     }
 }
 
@@ -799,7 +799,7 @@ static void ggml_backend_meta_set_tensor_async(ggml_backend_t backend, ggml_tens
         } break;
         default: {
             GGML_ABORT("fatal error");
-        } break;
+        }
     }
 }
 
@@ -839,7 +839,7 @@ static void ggml_backend_meta_get_tensor_async(ggml_backend_t backend, const ggm
         } break;
         default: {
             GGML_ABORT("fatal error");
-        } break;
+        }
     }
 }
 
@@ -1311,7 +1311,7 @@ struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(const str
             return {assume_sync ? GGML_BACKEND_SPLIT_AXIS_MIRRORED : GGML_BACKEND_SPLIT_AXIS_PARTIAL, {0}};
         }
         GGML_ABORT("fatal error");
-        return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
+        //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
     };
 
     auto handle_reshape = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
@@ -1345,7 +1345,7 @@ struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(const str
             }
             default: {
                 GGML_ABORT("fatal error");
-                return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
+                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
             }
         }
     };
@@ -1373,7 +1373,7 @@ struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(const str
             return src_split_states[0];
         }
         GGML_ABORT("view of permuted tensor not implemented");
-        return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
+        //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
     };
 
     auto handle_permute = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
@@ -1390,7 +1390,7 @@ struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(const str
             }
             default: {
                 GGML_ABORT("fatal error");
-                return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
+                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
             }
         }
     };

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -57,8 +57,8 @@ struct ggml_backend_meta_device_context {
     std::string description;
 
     ggml_backend_meta_device_context(
-            std::vector<ggml_backend_dev_t> simple_devs, ggml_backend_meta_get_split_state_t get_splite_state, void * get_split_state_ud) :
-            simple_devs(std::move(simple_devs)), get_split_state(get_splite_state), get_split_state_ud(get_split_state_ud) {
+            std::vector<ggml_backend_dev_t> simple_devs, ggml_backend_meta_get_split_state_t get_split_state, void * get_split_state_ud) :
+            simple_devs(std::move(simple_devs)), get_split_state(get_split_state), get_split_state_ud(get_split_state_ud) {
         name        = std::string("Meta(");
         description = std::string("Meta(");
         for (size_t i = 0; i < simple_devs.size(); i++) {

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -192,13 +192,13 @@ bool ggml_backend_dev_is_meta(ggml_backend_dev_t dev) {
     return dev != nullptr && dev->iface.get_name == ggml_backend_meta_device_iface.get_name;
 }
 
-size_t ggml_backend_meta_dev_n_devs(ggml_backend_dev_t meta_dev) {
+static size_t ggml_backend_meta_dev_n_devs(ggml_backend_dev_t meta_dev) {
     GGML_ASSERT(ggml_backend_dev_is_meta(meta_dev));
     const ggml_backend_meta_device_context * meta_dev_ctx = (const ggml_backend_meta_device_context *) meta_dev->context;
     return meta_dev_ctx->simple_devs.size();
 }
 
-ggml_backend_dev_t ggml_backend_meta_dev_simple_dev(ggml_backend_dev_t meta_dev, size_t index) {
+static ggml_backend_dev_t ggml_backend_meta_dev_simple_dev(ggml_backend_dev_t meta_dev, size_t index) {
     GGML_ASSERT(ggml_backend_dev_is_meta(meta_dev));
     const ggml_backend_meta_device_context * meta_dev_ctx = (const ggml_backend_meta_device_context *) meta_dev->context;
     GGML_ASSERT(index < meta_dev_ctx->simple_devs.size());
@@ -261,10 +261,23 @@ struct ggml_backend_meta_buffer_type_context {
     }
 };
 
+static size_t ggml_backend_meta_buft_n_bufts(ggml_backend_buffer_type_t meta_buft) {
+    GGML_ASSERT(ggml_backend_buft_is_meta(meta_buft));
+    const ggml_backend_meta_buffer_type_context * meta_buft_ctx = (const ggml_backend_meta_buffer_type_context *) meta_buft->context;
+    return meta_buft_ctx->simple_bufts.size();
+}
+
 static const char * ggml_backend_meta_buffer_type_get_name(ggml_backend_buffer_type_t buft) {
     GGML_ASSERT(ggml_backend_buft_is_meta(buft));
     const ggml_backend_meta_buffer_type_context * meta_buft_ctx = (const ggml_backend_meta_buffer_type_context *) buft->context;
     return meta_buft_ctx->name.c_str();
+}
+
+static ggml_backend_buffer_type_t ggml_backend_meta_buft_simple_buft(ggml_backend_buffer_type_t meta_buft, size_t index) {
+    GGML_ASSERT(ggml_backend_buft_is_meta(meta_buft));
+    const ggml_backend_meta_buffer_type_context * meta_buft_ctx = (const ggml_backend_meta_buffer_type_context *) meta_buft->context;
+    GGML_ASSERT(index < meta_buft_ctx->simple_bufts.size());
+    return meta_buft_ctx->simple_bufts[index];
 }
 
 static ggml_backend_buffer_t ggml_backend_meta_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size);
@@ -362,25 +375,12 @@ static ggml_backend_buffer_type_t ggml_backend_meta_device_get_host_buffer_type(
         if (host_buft == nullptr) {
             host_buft = simple_host_buft;
         } else if (host_buft != simple_host_buft) {
-            // if different simple devices have different host buffer types, 
+            // if different simple devices have different host buffer types,
             // we cannot provide a single host buffer type for the meta device
             return nullptr;
         }
     }
     return host_buft;
-}
-
-size_t ggml_backend_meta_buft_n_bufts(ggml_backend_buffer_type_t meta_buft) {
-    GGML_ASSERT(ggml_backend_buft_is_meta(meta_buft));
-    const ggml_backend_meta_buffer_type_context * meta_buft_ctx = (const ggml_backend_meta_buffer_type_context *) meta_buft->context;
-    return meta_buft_ctx->simple_bufts.size();
-}
-
-ggml_backend_buffer_type_t ggml_backend_meta_buft_simple_buft(ggml_backend_buffer_type_t meta_buft, size_t index) {
-    GGML_ASSERT(ggml_backend_buft_is_meta(meta_buft));
-    const ggml_backend_meta_buffer_type_context * meta_buft_ctx = (const ggml_backend_meta_buffer_type_context *) meta_buft->context;
-    GGML_ASSERT(index < meta_buft_ctx->simple_bufts.size());
-    return meta_buft_ctx->simple_bufts[index];
 }
 
 //
@@ -415,6 +415,493 @@ static void ggml_backend_meta_buffer_free_buffer(ggml_backend_buffer_t buffer) {
         ggml_free(ctx);
     }
     delete buf_ctx;
+}
+
+static size_t ggml_backend_meta_buffer_n_bufs(ggml_backend_buffer_t meta_buf) {
+    GGML_ASSERT(ggml_backend_buffer_is_meta(meta_buf));
+    ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) meta_buf->context;
+    return buf_ctx->buf_configs.size();
+}
+
+static ggml_backend_buffer_t ggml_backend_meta_buffer_simple_buffer(ggml_backend_buffer_t meta_buf, size_t index) {
+    GGML_ASSERT(ggml_backend_buffer_is_meta(meta_buf));
+    ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) meta_buf->context;
+    GGML_ASSERT(index < buf_ctx->buf_configs.size());
+    return buf_ctx->buf_configs[index].buf;
+}
+
+static struct ggml_tensor * ggml_backend_meta_buffer_simple_tensor(const struct ggml_tensor * tensor, size_t index) {
+    GGML_ASSERT(ggml_backend_buffer_is_meta(tensor->buffer));
+    ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) tensor->buffer->context;
+    GGML_ASSERT(index < buf_ctx->buf_configs.size());
+
+    auto it = buf_ctx->simple_tensors.find(tensor);
+    if (it == buf_ctx->simple_tensors.end()) {
+        return nullptr;
+    }
+    return it->second[index];
+}
+
+static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(const struct ggml_tensor * tensor, bool assume_sync) {
+    const size_t n_bufs = ggml_backend_meta_buffer_n_bufs(tensor->buffer);
+    ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) tensor->buffer->context;
+
+    auto split_states_equal = [&](const ggml_backend_meta_split_state & a, const ggml_backend_meta_split_state & b) -> bool {
+        if (a.axis != b.axis) {
+            return false;
+        }
+        for (size_t j = 0; j < n_bufs; j++) {
+            if (a.ne[j] != b.ne[j]) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    auto handle_generic = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states, bool scalar_only) -> ggml_backend_meta_split_state {
+        ggml_backend_meta_split_state homogeneous_src_split_state = {GGML_BACKEND_SPLIT_AXIS_NONE, {0}};
+        for (size_t i = 0; i < GGML_MAX_SRC; i++) {
+            if (tensor->src[i] == nullptr || tensor->src[i] == tensor) {
+                continue;
+            }
+            if (homogeneous_src_split_state.axis == GGML_BACKEND_SPLIT_AXIS_NONE) {
+                homogeneous_src_split_state = src_split_states[i];
+            } else if (!split_states_equal(src_split_states[i], homogeneous_src_split_state)) {
+                homogeneous_src_split_state = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
+                break;
+            }
+        }
+        if (homogeneous_src_split_state.axis == GGML_BACKEND_SPLIT_AXIS_NONE) {
+            homogeneous_src_split_state = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
+        }
+        if (scalar_only && homogeneous_src_split_state.axis >= 0 && homogeneous_src_split_state.axis < GGML_MAX_DIMS) {
+            homogeneous_src_split_state = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
+        }
+        GGML_ASSERT(homogeneous_src_split_state.axis != GGML_BACKEND_SPLIT_AXIS_UNKNOWN);
+        return homogeneous_src_split_state;
+    };
+
+    // Some ops process data on a per-row bases:
+    auto handle_per_row = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
+        GGML_ASSERT(src_split_states[0].axis != GGML_BACKEND_SPLIT_AXIS_0);
+        return src_split_states[0];
+    };
+
+    // Some ops broadcast the src1 data across src0:
+    auto handle_bin_bcast = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
+        if (src_split_states[0].axis >= 0 && src_split_states[0].axis < GGML_MAX_DIMS &&
+                tensor->src[1]->ne[src_split_states[0].axis] == 1 && src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
+            return src_split_states[0];
+        }
+        if (src_split_states[2].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && (src_split_states[0].axis == src_split_states[1].axis ||
+                (src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_PARTIAL))) {
+            return src_split_states[0]; // GGML_OP_ADD_ID
+        }
+        GGML_ASSERT(tensor->src[2] == nullptr || src_split_states[2].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+        return handle_generic(src_split_states, /*scalar_only =*/ false);
+    };
+
+    auto handle_concat = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
+        if (src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_split_states[1].axis >= 0 && src_split_states[1].axis < GGML_MAX_DIMS) {
+            GGML_ASSERT(ggml_get_op_params_i32(tensor, 0) != src_split_states[1].axis);
+            return src_split_states[1];
+        }
+        if (src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_split_states[0].axis >= 0 && src_split_states[0].axis < GGML_MAX_DIMS) {
+            GGML_ASSERT(ggml_get_op_params_i32(tensor, 0) != src_split_states[0].axis);
+            return src_split_states[0];
+        }
+        return handle_generic(src_split_states, /*scalar_only =*/ true);
+    };
+
+    auto handle_mul_mat = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
+        if (src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
+            return {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}};
+        }
+        if (src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_1 && src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
+            ggml_backend_meta_split_state ret = src_split_states[0];
+            ret.axis = GGML_BACKEND_SPLIT_AXIS_0;
+            return ret;
+        }
+        if (src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_0 && src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_0) {
+            for (size_t j = 0; j < n_bufs; j++) {
+                GGML_ASSERT(src_split_states[0].ne[j] == src_split_states[1].ne[j]);
+            }
+            return {assume_sync ? GGML_BACKEND_SPLIT_AXIS_MIRRORED : GGML_BACKEND_SPLIT_AXIS_PARTIAL, {0}};
+        }
+        GGML_ABORT("fatal error");
+        //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
+    };
+
+    auto handle_reshape = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
+        switch (src_split_states[0].axis) {
+            case GGML_BACKEND_SPLIT_AXIS_0:
+            case GGML_BACKEND_SPLIT_AXIS_1:
+            case GGML_BACKEND_SPLIT_AXIS_2:
+            case GGML_BACKEND_SPLIT_AXIS_3: {
+                GGML_ASSERT(!ggml_is_permuted(tensor) && !ggml_is_permuted(tensor->src[0]));
+                int64_t base_ne_in = 1;
+                for (int dim = 0; dim <= src_split_states[0].axis; dim++) {
+                    base_ne_in *= tensor->src[0]->ne[dim];
+                }
+                int64_t base_ne_out = 1;
+                for (int dim = 0; dim < GGML_MAX_DIMS; dim++) {
+                    const int64_t base_ne_out_next = base_ne_out *= tensor->ne[dim];
+                    if (base_ne_out_next == base_ne_in) {
+                        return {ggml_backend_meta_split_axis(dim), {0}};
+                    }
+                    if (base_ne_out_next > base_ne_in) {
+                        GGML_ASSERT(dim + 1 < GGML_MAX_DIMS);
+                        return {ggml_backend_meta_split_axis(dim + 1), {0}};
+                    }
+                    base_ne_out = base_ne_out_next;
+                }
+                GGML_ABORT("shape mismatch for %s", ggml_op_name(tensor->op));
+            }
+            case GGML_BACKEND_SPLIT_AXIS_MIRRORED:
+            case GGML_BACKEND_SPLIT_AXIS_PARTIAL: {
+                return src_split_states[0];
+            }
+            default: {
+                GGML_ABORT("fatal error");
+                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
+            }
+        }
+    };
+
+    auto handle_view = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
+        const int axis = src_split_states[0].axis;
+        bool only_views_of_non_split_dim = true;
+        for (int dim = 0; dim < GGML_MAX_DIMS; dim++) {
+            if (tensor->nb[dim] != tensor->src[0]->nb[dim]) {
+                only_views_of_non_split_dim = false;
+                break;
+            }
+            if (dim == axis && tensor->ne[dim] != tensor->src[0]->ne[dim]) {
+                only_views_of_non_split_dim = false;
+                break;
+            }
+        }
+        if (only_views_of_non_split_dim) {
+            return src_split_states[0];
+        }
+        if (!ggml_is_permuted(tensor) && !ggml_is_permuted(tensor->src[0])) {
+            return handle_reshape(src_split_states);
+        }
+        if (src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED || src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_PARTIAL) {
+            return src_split_states[0];
+        }
+        GGML_ABORT("view of permuted tensor not implemented");
+        //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
+    };
+
+    auto handle_permute = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
+        switch (src_split_states[0].axis) {
+            case GGML_BACKEND_SPLIT_AXIS_0:
+            case GGML_BACKEND_SPLIT_AXIS_1:
+            case GGML_BACKEND_SPLIT_AXIS_2:
+            case GGML_BACKEND_SPLIT_AXIS_3: {
+                return {ggml_backend_meta_split_axis(tensor->op_params[src_split_states[0].axis]), {0}};
+            }
+            case GGML_BACKEND_SPLIT_AXIS_MIRRORED:
+            case GGML_BACKEND_SPLIT_AXIS_PARTIAL: {
+                return src_split_states[0];
+            }
+            default: {
+                GGML_ABORT("fatal error");
+                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
+            }
+        }
+    };
+
+    auto handle_set_rows = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
+        GGML_ASSERT(src_split_states[0].axis != GGML_BACKEND_SPLIT_AXIS_1);
+        GGML_ASSERT(src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+        GGML_ASSERT(split_states_equal(src_split_states[0], src_split_states[2]));
+        return src_split_states[0];
+    };
+
+    auto handle_rope = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
+        GGML_ASSERT(src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+        return src_split_states[0];
+    };
+
+    auto handle_flash_attn_ext = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
+        GGML_ASSERT(                             src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_2);
+        GGML_ASSERT(                             src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_2);
+        GGML_ASSERT(                             src_split_states[2].axis == GGML_BACKEND_SPLIT_AXIS_2);
+        GGML_ASSERT(tensor->src[4] == nullptr || src_split_states[3].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+        GGML_ASSERT(tensor->src[4] == nullptr || src_split_states[4].axis == GGML_BACKEND_SPLIT_AXIS_0);
+        return {GGML_BACKEND_SPLIT_AXIS_1, {0}};
+    };
+
+    auto calculate_split_state = [&]() -> ggml_backend_meta_split_state {
+        if (ggml_backend_buffer_get_usage(tensor->buffer) != GGML_BACKEND_BUFFER_USAGE_COMPUTE && tensor->view_src == nullptr) {
+            ggml_backend_dev_t dev = ggml_backend_buft_get_device(ggml_backend_buffer_get_type(tensor->buffer));
+            const ggml_backend_meta_device_context * dev_ctx = (const ggml_backend_meta_device_context *) dev->context;
+            ggml_backend_meta_split_state ret = dev_ctx->get_split_state(tensor, dev_ctx->get_split_state_ud);
+            if (ret.axis >= 0 && ret.axis <= GGML_MAX_DIMS) {
+                const int64_t granularity = ret.axis == GGML_BACKEND_SPLIT_AXIS_0 ? ggml_blck_size(tensor->type) : 1;
+                int64_t ne_sum = 0;
+                for (size_t j = 0; j < n_bufs; j++) {
+                    GGML_ASSERT(ret.ne[j] % granularity == 0);
+                    ne_sum += ret.ne[j];
+                }
+                GGML_ASSERT(ne_sum == tensor->ne[ret.axis]);
+            }
+            return ret;
+        }
+
+        std::vector<ggml_backend_meta_split_state> src_split_states(GGML_MAX_SRC, {GGML_BACKEND_SPLIT_AXIS_NONE, {0}});
+        for (size_t i = 0; i < GGML_MAX_SRC; i++) {
+            if (tensor->src[i] == nullptr || tensor->src[i] == tensor) {
+                src_split_states[i] = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
+                continue;
+            }
+            src_split_states[i] = ggml_backend_meta_get_split_state(tensor->src[i], /*assume_sync =*/ true);
+        }
+
+        ggml_backend_meta_split_state split_state;
+        switch (tensor->op) {
+            case GGML_OP_NONE: {
+                split_state = {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}};
+            } break;
+            case GGML_OP_DUP: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
+            } break;
+            case GGML_OP_ADD:
+            case GGML_OP_ADD_ID: {
+                split_state = handle_bin_bcast(src_split_states);
+            } break;
+            case GGML_OP_ADD1:
+            case GGML_OP_ACC: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
+            } break;
+            case GGML_OP_SUB:
+            case GGML_OP_MUL:
+            case GGML_OP_DIV: {
+                split_state = handle_bin_bcast(src_split_states);
+            } break;
+            case GGML_OP_SQR:
+            case GGML_OP_SQRT:
+            case GGML_OP_LOG:
+            case GGML_OP_SIN:
+            case GGML_OP_COS: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
+            } break;
+            case GGML_OP_SUM: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
+            } break;
+            case GGML_OP_SUM_ROWS:
+            case GGML_OP_CUMSUM:
+            case GGML_OP_MEAN:
+            case GGML_OP_ARGMAX:
+            case GGML_OP_COUNT_EQUAL: {
+                split_state = handle_per_row(src_split_states);
+            } break;
+            case GGML_OP_REPEAT:
+            case GGML_OP_REPEAT_BACK: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
+            } break;
+            case GGML_OP_CONCAT: {
+                split_state = handle_concat(src_split_states);
+            } break;
+            case GGML_OP_SILU_BACK: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
+            } break;
+            case GGML_OP_NORM:
+            case GGML_OP_RMS_NORM:
+            case GGML_OP_RMS_NORM_BACK:
+            case GGML_OP_GROUP_NORM:
+            case GGML_OP_L2_NORM: {
+                split_state = handle_per_row(src_split_states);
+            } break;
+            case GGML_OP_MUL_MAT:
+            case GGML_OP_MUL_MAT_ID: {
+                split_state = handle_mul_mat(src_split_states);
+            } break;
+            case GGML_OP_OUT_PROD: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
+            } break;
+            case GGML_OP_SCALE: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
+            } break;
+            case GGML_OP_SET:
+            case GGML_OP_CPY: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
+            } break;
+            case GGML_OP_CONT:
+            case GGML_OP_RESHAPE: {
+                split_state = handle_reshape(src_split_states);
+            } break;
+            case GGML_OP_VIEW: {
+                split_state = handle_view(src_split_states);
+            } break;
+            case GGML_OP_PERMUTE: {
+                split_state = handle_permute(src_split_states);
+            } break;
+            case GGML_OP_TRANSPOSE:
+            case GGML_OP_GET_ROWS:
+            case GGML_OP_GET_ROWS_BACK: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
+            } break;
+            case GGML_OP_SET_ROWS: {
+                split_state = handle_set_rows(src_split_states);
+            } break;
+            case GGML_OP_DIAG:
+            case GGML_OP_DIAG_MASK_INF:
+            case GGML_OP_DIAG_MASK_ZERO: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
+            } break;
+            case GGML_OP_SOFT_MAX:
+            case GGML_OP_SOFT_MAX_BACK: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
+            } break;
+            case GGML_OP_ROPE: {
+                split_state = handle_rope(src_split_states);
+            } break;
+            case GGML_OP_ROPE_BACK: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
+            } break;
+            case GGML_OP_CLAMP: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
+            } break;
+            case GGML_OP_CONV_TRANSPOSE_1D:
+            case GGML_OP_IM2COL:
+            case GGML_OP_IM2COL_BACK:
+            case GGML_OP_IM2COL_3D:
+            case GGML_OP_CONV_2D:
+            case GGML_OP_CONV_3D:
+            case GGML_OP_CONV_2D_DW:
+            case GGML_OP_CONV_TRANSPOSE_2D:
+            case GGML_OP_POOL_1D:
+            case GGML_OP_POOL_2D:
+            case GGML_OP_POOL_2D_BACK:
+            case GGML_OP_UPSCALE:
+            case GGML_OP_PAD:
+            case GGML_OP_PAD_REFLECT_1D:
+            case GGML_OP_ROLL:
+            case GGML_OP_ARANGE:
+            case GGML_OP_TIMESTEP_EMBEDDING: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
+            } break;
+            case GGML_OP_ARGSORT:
+            case GGML_OP_TOP_K: {
+                split_state = handle_per_row(src_split_states);
+            } break;
+            case GGML_OP_LEAKY_RELU: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
+            } break;
+            case GGML_OP_TRI:
+            case GGML_OP_FILL: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
+            } break;
+            case GGML_OP_FLASH_ATTN_EXT: {
+                split_state = handle_flash_attn_ext(src_split_states);
+            } break;
+            case GGML_OP_FLASH_ATTN_BACK:
+            case GGML_OP_SSM_CONV:
+            case GGML_OP_SSM_SCAN:
+            case GGML_OP_WIN_PART:
+            case GGML_OP_WIN_UNPART:
+            case GGML_OP_GET_REL_POS:
+            case GGML_OP_ADD_REL_POS:
+            case GGML_OP_RWKV_WKV6:
+            case GGML_OP_GATED_LINEAR_ATTN:
+            case GGML_OP_RWKV_WKV7:
+            case GGML_OP_SOLVE_TRI: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
+            } break;
+            case GGML_OP_UNARY: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
+            } break;
+            case GGML_OP_MAP_CUSTOM1:
+            case GGML_OP_MAP_CUSTOM2:
+            case GGML_OP_MAP_CUSTOM3:
+            case GGML_OP_CUSTOM: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
+            } break;
+            case GGML_OP_CROSS_ENTROPY_LOSS:
+            case GGML_OP_CROSS_ENTROPY_LOSS_BACK: {
+                split_state = handle_per_row(src_split_states);
+            } break;
+            case GGML_OP_OPT_STEP_ADAMW:
+            case GGML_OP_OPT_STEP_SGD:
+            case GGML_OP_GLU: {
+                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
+            } break;
+            default: {
+                GGML_ABORT("ggml op not implemented: %s", ggml_op_name(tensor->op));
+                split_state = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
+            } break;
+        }
+        if (split_state.axis >= 0 && split_state.axis < GGML_MAX_DIMS) {
+            bool src_split_by_axis_found = false;
+            const size_t n_bufs = ggml_backend_meta_buffer_n_bufs(tensor->buffer);
+
+            for (size_t i = 0; i < GGML_MAX_SRC; i++) {
+                if (tensor->src[i] == nullptr || src_split_states[i].axis < 0 || src_split_states[i].axis >= GGML_MAX_DIMS) {
+                    continue;
+                }
+                if (src_split_by_axis_found) {
+                    for (size_t j = 0; j < n_bufs; j++) {
+                        // Assert that ratio is consistent:
+                        GGML_ASSERT(   split_state.ne[j] * tensor->src[i]->ne[src_split_states[i].axis]
+                            == src_split_states[i].ne[j] *         tensor->ne[split_state.axis]);
+                    }
+                } else {
+                    for (size_t j = 0; j < n_bufs; j++) {
+                        // Take over ratio from src:
+                        split_state.ne[j] = src_split_states[i].ne[j] * tensor->ne[split_state.axis];
+                        GGML_ASSERT(split_state.ne[j] % tensor->src[i]->ne[src_split_states[i].axis] == 0);
+                        split_state.ne[j] /= tensor->src[i]->ne[src_split_states[i].axis];
+                    }
+                }
+                src_split_by_axis_found = true;
+            }
+            GGML_ASSERT(src_split_by_axis_found);
+        }
+        return split_state;
+    };
+
+    const std::pair key = std::make_pair(tensor, assume_sync);
+
+    if (buf_ctx->split_state_cache.find(key) == buf_ctx->split_state_cache.end()) {
+        buf_ctx->split_state_cache[key] = calculate_split_state();
+        if (buf_ctx->debug > 0) {
+            std::string srcs_info;
+            for (size_t i = 0; i < GGML_MAX_SRC; i++) {
+                if (tensor->src[i] == nullptr) {
+                    continue;
+                }
+                if (!srcs_info.empty()) {
+                    srcs_info += ", ";
+                }
+                const ggml_backend_meta_split_state split_state = ggml_backend_meta_get_split_state(tensor->src[0], true);
+                const char * axis_name = ggml_backend_meta_split_axis_name(split_state.axis);
+                std::string ne_info;
+                for (size_t j = 0; j < n_bufs; j++) {
+                    if (!ne_info.empty()) {
+                        ne_info += ", ";
+                    }
+                    ne_info += std::to_string(split_state.ne[j]);
+                }
+                srcs_info += std::string(tensor->src[i]->name) + "[" + ggml_op_name(tensor->src[i]->op) + ", " + axis_name + ", {" + ne_info + "}]";
+            }
+            std::string ne_info;
+            for (size_t j = 0; j < n_bufs; j++) {
+                if (!ne_info.empty()) {
+                    ne_info += ", ";
+                }
+                ne_info += std::to_string(buf_ctx->split_state_cache[key].ne[j]);
+            }
+            GGML_LOG_DEBUG("SPLIT_STATE: {%s} -> %s[%s, %s, {%s}]\n", srcs_info.c_str(), tensor->name, ggml_op_name(tensor->op),
+                ggml_backend_meta_split_axis_name(buf_ctx->split_state_cache[key].axis), ne_info.c_str());
+        }
+    }
+
+    ggml_backend_meta_split_state ret = buf_ctx->split_state_cache[key];
+    GGML_ASSERT(ret.axis != GGML_BACKEND_SPLIT_AXIS_NONE && ret.axis != GGML_BACKEND_SPLIT_AXIS_UNKNOWN);
+    return ret;
 }
 
 static void * ggml_backend_meta_buffer_get_base(ggml_backend_buffer_t buffer) {
@@ -613,31 +1100,6 @@ static const ggml_backend_buffer_i ggml_backend_meta_buffer_iface = {
 
 bool ggml_backend_buffer_is_meta(ggml_backend_buffer_t buf) {
     return buf != nullptr && buf->iface.free_buffer == ggml_backend_meta_buffer_iface.free_buffer;
-}
-
-size_t ggml_backend_meta_buffer_n_bufs(ggml_backend_buffer_t meta_buf) {
-    GGML_ASSERT(ggml_backend_buffer_is_meta(meta_buf));
-    ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) meta_buf->context;
-    return buf_ctx->buf_configs.size();
-}
-
-ggml_backend_buffer_t ggml_backend_meta_buffer_simple_buffer(ggml_backend_buffer_t meta_buf, size_t index) {
-    GGML_ASSERT(ggml_backend_buffer_is_meta(meta_buf));
-    ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) meta_buf->context;
-    GGML_ASSERT(index < buf_ctx->buf_configs.size());
-    return buf_ctx->buf_configs[index].buf;
-}
-
-struct ggml_tensor * ggml_backend_meta_buffer_simple_tensor(const struct ggml_tensor * tensor, size_t index) {
-    GGML_ASSERT(ggml_backend_buffer_is_meta(tensor->buffer));
-    ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) tensor->buffer->context;
-    GGML_ASSERT(index < buf_ctx->buf_configs.size());
-
-    auto it = buf_ctx->simple_tensors.find(tensor);
-    if (it == buf_ctx->simple_tensors.end()) {
-        return nullptr;
-    }
-    return it->second[index];
 }
 
 static ggml_backend_buffer_t ggml_backend_meta_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
@@ -1224,464 +1686,3 @@ ggml_backend_t ggml_backend_meta_simple_backend(ggml_backend_t meta_backend, siz
     return backend_ctx->backend_configs[index].backend;
 }
 
-struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(const struct ggml_tensor * tensor, bool assume_sync) {
-    const size_t n_bufs = ggml_backend_meta_buffer_n_bufs(tensor->buffer);
-    ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) tensor->buffer->context;
-
-    auto split_states_equal = [&](const ggml_backend_meta_split_state & a, const ggml_backend_meta_split_state & b) -> bool {
-        if (a.axis != b.axis) {
-            return false;
-        }
-        for (size_t j = 0; j < n_bufs; j++) {
-            if (a.ne[j] != b.ne[j]) {
-                return false;
-            }
-        }
-        return true;
-    };
-
-    auto handle_generic = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states, bool scalar_only) -> ggml_backend_meta_split_state {
-        ggml_backend_meta_split_state homogeneous_src_split_state = {GGML_BACKEND_SPLIT_AXIS_NONE, {0}};
-        for (size_t i = 0; i < GGML_MAX_SRC; i++) {
-            if (tensor->src[i] == nullptr || tensor->src[i] == tensor) {
-                continue;
-            }
-            if (homogeneous_src_split_state.axis == GGML_BACKEND_SPLIT_AXIS_NONE) {
-                homogeneous_src_split_state = src_split_states[i];
-            } else if (!split_states_equal(src_split_states[i], homogeneous_src_split_state)) {
-                homogeneous_src_split_state = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
-                break;
-            }
-        }
-        if (homogeneous_src_split_state.axis == GGML_BACKEND_SPLIT_AXIS_NONE) {
-            homogeneous_src_split_state = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
-        }
-        if (scalar_only && homogeneous_src_split_state.axis >= 0 && homogeneous_src_split_state.axis < GGML_MAX_DIMS) {
-            homogeneous_src_split_state = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
-        }
-        GGML_ASSERT(homogeneous_src_split_state.axis != GGML_BACKEND_SPLIT_AXIS_UNKNOWN);
-        return homogeneous_src_split_state;
-    };
-
-    // Some ops process data on a per-row bases:
-    auto handle_per_row = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
-        GGML_ASSERT(src_split_states[0].axis != GGML_BACKEND_SPLIT_AXIS_0);
-        return src_split_states[0];
-    };
-
-    // Some ops broadcast the src1 data across src0:
-    auto handle_bin_bcast = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
-        if (src_split_states[0].axis >= 0 && src_split_states[0].axis < GGML_MAX_DIMS &&
-                tensor->src[1]->ne[src_split_states[0].axis] == 1 && src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
-            return src_split_states[0];
-        }
-        if (src_split_states[2].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && (src_split_states[0].axis == src_split_states[1].axis ||
-                (src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_PARTIAL))) {
-            return src_split_states[0]; // GGML_OP_ADD_ID
-        }
-        GGML_ASSERT(tensor->src[2] == nullptr || src_split_states[2].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
-        return handle_generic(src_split_states, /*scalar_only =*/ false);
-    };
-
-    auto handle_concat = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
-        if (src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_split_states[1].axis >= 0 && src_split_states[1].axis < GGML_MAX_DIMS) {
-            GGML_ASSERT(ggml_get_op_params_i32(tensor, 0) != src_split_states[1].axis);
-            return src_split_states[1];
-        }
-        if (src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_split_states[0].axis >= 0 && src_split_states[0].axis < GGML_MAX_DIMS) {
-            GGML_ASSERT(ggml_get_op_params_i32(tensor, 0) != src_split_states[0].axis);
-            return src_split_states[0];
-        }
-        return handle_generic(src_split_states, /*scalar_only =*/ true);
-    };
-
-    auto handle_mul_mat = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
-        if (src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED && src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
-            return {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}};
-        }
-        if (src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_1 && src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
-            ggml_backend_meta_split_state ret = src_split_states[0];
-            ret.axis = GGML_BACKEND_SPLIT_AXIS_0;
-            return ret;
-        }
-        if (src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_0 && src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_0) {
-            for (size_t j = 0; j < n_bufs; j++) {
-                GGML_ASSERT(src_split_states[0].ne[j] == src_split_states[1].ne[j]);
-            }
-            return {assume_sync ? GGML_BACKEND_SPLIT_AXIS_MIRRORED : GGML_BACKEND_SPLIT_AXIS_PARTIAL, {0}};
-        }
-        GGML_ABORT("fatal error");
-        //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
-    };
-
-    auto handle_reshape = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
-        switch (src_split_states[0].axis) {
-            case GGML_BACKEND_SPLIT_AXIS_0:
-            case GGML_BACKEND_SPLIT_AXIS_1:
-            case GGML_BACKEND_SPLIT_AXIS_2:
-            case GGML_BACKEND_SPLIT_AXIS_3: {
-                GGML_ASSERT(!ggml_is_permuted(tensor) && !ggml_is_permuted(tensor->src[0]));
-                int64_t base_ne_in = 1;
-                for (int dim = 0; dim <= src_split_states[0].axis; dim++) {
-                    base_ne_in *= tensor->src[0]->ne[dim];
-                }
-                int64_t base_ne_out = 1;
-                for (int dim = 0; dim < GGML_MAX_DIMS; dim++) {
-                    const int64_t base_ne_out_next = base_ne_out *= tensor->ne[dim];
-                    if (base_ne_out_next == base_ne_in) {
-                        return {ggml_backend_meta_split_axis(dim), {0}};
-                    }
-                    if (base_ne_out_next > base_ne_in) {
-                        GGML_ASSERT(dim + 1 < GGML_MAX_DIMS);
-                        return {ggml_backend_meta_split_axis(dim + 1), {0}};
-                    }
-                    base_ne_out = base_ne_out_next;
-                }
-                GGML_ABORT("shape mismatch for %s", ggml_op_name(tensor->op));
-            }
-            case GGML_BACKEND_SPLIT_AXIS_MIRRORED:
-            case GGML_BACKEND_SPLIT_AXIS_PARTIAL: {
-                return src_split_states[0];
-            }
-            default: {
-                GGML_ABORT("fatal error");
-                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
-            }
-        }
-    };
-
-    auto handle_view = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
-        const int axis = src_split_states[0].axis;
-        bool only_views_of_non_split_dim = true;
-        for (int dim = 0; dim < GGML_MAX_DIMS; dim++) {
-            if (tensor->nb[dim] != tensor->src[0]->nb[dim]) {
-                only_views_of_non_split_dim = false;
-                break;
-            }
-            if (dim == axis && tensor->ne[dim] != tensor->src[0]->ne[dim]) {
-                only_views_of_non_split_dim = false;
-                break;
-            }
-        }
-        if (only_views_of_non_split_dim) {
-            return src_split_states[0];
-        }
-        if (!ggml_is_permuted(tensor) && !ggml_is_permuted(tensor->src[0])) {
-            return handle_reshape(src_split_states);
-        }
-        if (src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED || src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_PARTIAL) {
-            return src_split_states[0];
-        }
-        GGML_ABORT("view of permuted tensor not implemented");
-        //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
-    };
-
-    auto handle_permute = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
-        switch (src_split_states[0].axis) {
-            case GGML_BACKEND_SPLIT_AXIS_0:
-            case GGML_BACKEND_SPLIT_AXIS_1:
-            case GGML_BACKEND_SPLIT_AXIS_2:
-            case GGML_BACKEND_SPLIT_AXIS_3: {
-                return {ggml_backend_meta_split_axis(tensor->op_params[src_split_states[0].axis]), {0}};
-            }
-            case GGML_BACKEND_SPLIT_AXIS_MIRRORED:
-            case GGML_BACKEND_SPLIT_AXIS_PARTIAL: {
-                return src_split_states[0];
-            }
-            default: {
-                GGML_ABORT("fatal error");
-                //return {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
-            }
-        }
-    };
-
-    auto handle_set_rows = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
-        GGML_ASSERT(src_split_states[0].axis != GGML_BACKEND_SPLIT_AXIS_1);
-        GGML_ASSERT(src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
-        GGML_ASSERT(split_states_equal(src_split_states[0], src_split_states[2]));
-        return src_split_states[0];
-    };
-
-    auto handle_rope = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
-        GGML_ASSERT(src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
-        return src_split_states[0];
-    };
-
-    auto handle_flash_attn_ext = [&](const std::vector<ggml_backend_meta_split_state> & src_split_states) -> ggml_backend_meta_split_state {
-        GGML_ASSERT(                             src_split_states[0].axis == GGML_BACKEND_SPLIT_AXIS_2);
-        GGML_ASSERT(                             src_split_states[1].axis == GGML_BACKEND_SPLIT_AXIS_2);
-        GGML_ASSERT(                             src_split_states[2].axis == GGML_BACKEND_SPLIT_AXIS_2);
-        GGML_ASSERT(tensor->src[4] == nullptr || src_split_states[3].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED);
-        GGML_ASSERT(tensor->src[4] == nullptr || src_split_states[4].axis == GGML_BACKEND_SPLIT_AXIS_0);
-        return {GGML_BACKEND_SPLIT_AXIS_1, {0}};
-    };
-
-    auto calculate_split_state = [&]() -> ggml_backend_meta_split_state {
-        if (ggml_backend_buffer_get_usage(tensor->buffer) != GGML_BACKEND_BUFFER_USAGE_COMPUTE && tensor->view_src == nullptr) {
-            ggml_backend_dev_t dev = ggml_backend_buft_get_device(ggml_backend_buffer_get_type(tensor->buffer));
-            const ggml_backend_meta_device_context * dev_ctx = (const ggml_backend_meta_device_context *) dev->context;
-            ggml_backend_meta_split_state ret = dev_ctx->get_split_state(tensor, dev_ctx->get_split_state_ud);
-            if (ret.axis >= 0 && ret.axis <= GGML_MAX_DIMS) {
-                const int64_t granularity = ret.axis == GGML_BACKEND_SPLIT_AXIS_0 ? ggml_blck_size(tensor->type) : 1;
-                int64_t ne_sum = 0;
-                for (size_t j = 0; j < n_bufs; j++) {
-                    GGML_ASSERT(ret.ne[j] % granularity == 0);
-                    ne_sum += ret.ne[j];
-                }
-                GGML_ASSERT(ne_sum == tensor->ne[ret.axis]);
-            }
-            return ret;
-        }
-
-        std::vector<ggml_backend_meta_split_state> src_split_states(GGML_MAX_SRC, {GGML_BACKEND_SPLIT_AXIS_NONE, {0}});
-        for (size_t i = 0; i < GGML_MAX_SRC; i++) {
-            if (tensor->src[i] == nullptr || tensor->src[i] == tensor) {
-                src_split_states[i] = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
-                continue;
-            }
-            src_split_states[i] = ggml_backend_meta_get_split_state(tensor->src[i], /*assume_sync =*/ true);
-        }
-
-        ggml_backend_meta_split_state split_state;
-        switch (tensor->op) {
-            case GGML_OP_NONE: {
-                split_state = {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}};
-            } break;
-            case GGML_OP_DUP: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
-            } break;
-            case GGML_OP_ADD:
-            case GGML_OP_ADD_ID: {
-                split_state = handle_bin_bcast(src_split_states);
-            } break;
-            case GGML_OP_ADD1:
-            case GGML_OP_ACC: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
-            } break;
-            case GGML_OP_SUB:
-            case GGML_OP_MUL:
-            case GGML_OP_DIV: {
-                split_state = handle_bin_bcast(src_split_states);
-            } break;
-            case GGML_OP_SQR:
-            case GGML_OP_SQRT:
-            case GGML_OP_LOG:
-            case GGML_OP_SIN:
-            case GGML_OP_COS: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
-            } break;
-            case GGML_OP_SUM: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
-            } break;
-            case GGML_OP_SUM_ROWS:
-            case GGML_OP_CUMSUM:
-            case GGML_OP_MEAN:
-            case GGML_OP_ARGMAX:
-            case GGML_OP_COUNT_EQUAL: {
-                split_state = handle_per_row(src_split_states);
-            } break;
-            case GGML_OP_REPEAT:
-            case GGML_OP_REPEAT_BACK: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
-            } break;
-            case GGML_OP_CONCAT: {
-                split_state = handle_concat(src_split_states);
-            } break;
-            case GGML_OP_SILU_BACK: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
-            } break;
-            case GGML_OP_NORM:
-            case GGML_OP_RMS_NORM:
-            case GGML_OP_RMS_NORM_BACK:
-            case GGML_OP_GROUP_NORM:
-            case GGML_OP_L2_NORM: {
-                split_state = handle_per_row(src_split_states);
-            } break;
-            case GGML_OP_MUL_MAT:
-            case GGML_OP_MUL_MAT_ID: {
-                split_state = handle_mul_mat(src_split_states);
-            } break;
-            case GGML_OP_OUT_PROD: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
-            } break;
-            case GGML_OP_SCALE: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
-            } break;
-            case GGML_OP_SET:
-            case GGML_OP_CPY: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
-            } break;
-            case GGML_OP_CONT:
-            case GGML_OP_RESHAPE: {
-                split_state = handle_reshape(src_split_states);
-            } break;
-            case GGML_OP_VIEW: {
-                split_state = handle_view(src_split_states);
-            } break;
-            case GGML_OP_PERMUTE: {
-                split_state = handle_permute(src_split_states);
-            } break;
-            case GGML_OP_TRANSPOSE:
-            case GGML_OP_GET_ROWS:
-            case GGML_OP_GET_ROWS_BACK: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
-            } break;
-            case GGML_OP_SET_ROWS: {
-                split_state = handle_set_rows(src_split_states);
-            } break;
-            case GGML_OP_DIAG:
-            case GGML_OP_DIAG_MASK_INF:
-            case GGML_OP_DIAG_MASK_ZERO: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
-            } break;
-            case GGML_OP_SOFT_MAX:
-            case GGML_OP_SOFT_MAX_BACK: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
-            } break;
-            case GGML_OP_ROPE: {
-                split_state = handle_rope(src_split_states);
-            } break;
-            case GGML_OP_ROPE_BACK: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
-            } break;
-            case GGML_OP_CLAMP: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
-            } break;
-            case GGML_OP_CONV_TRANSPOSE_1D:
-            case GGML_OP_IM2COL:
-            case GGML_OP_IM2COL_BACK:
-            case GGML_OP_IM2COL_3D:
-            case GGML_OP_CONV_2D:
-            case GGML_OP_CONV_3D:
-            case GGML_OP_CONV_2D_DW:
-            case GGML_OP_CONV_TRANSPOSE_2D:
-            case GGML_OP_POOL_1D:
-            case GGML_OP_POOL_2D:
-            case GGML_OP_POOL_2D_BACK:
-            case GGML_OP_UPSCALE:
-            case GGML_OP_PAD:
-            case GGML_OP_PAD_REFLECT_1D:
-            case GGML_OP_ROLL:
-            case GGML_OP_ARANGE:
-            case GGML_OP_TIMESTEP_EMBEDDING: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
-            } break;
-            case GGML_OP_ARGSORT:
-            case GGML_OP_TOP_K: {
-                split_state = handle_per_row(src_split_states);
-            } break;
-            case GGML_OP_LEAKY_RELU: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
-            } break;
-            case GGML_OP_TRI:
-            case GGML_OP_FILL: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
-            } break;
-            case GGML_OP_FLASH_ATTN_EXT: {
-                split_state = handle_flash_attn_ext(src_split_states);
-            } break;
-            case GGML_OP_FLASH_ATTN_BACK:
-            case GGML_OP_SSM_CONV:
-            case GGML_OP_SSM_SCAN:
-            case GGML_OP_WIN_PART:
-            case GGML_OP_WIN_UNPART:
-            case GGML_OP_GET_REL_POS:
-            case GGML_OP_ADD_REL_POS:
-            case GGML_OP_RWKV_WKV6:
-            case GGML_OP_GATED_LINEAR_ATTN:
-            case GGML_OP_RWKV_WKV7:
-            case GGML_OP_SOLVE_TRI: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
-            } break;
-            case GGML_OP_UNARY: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
-            } break;
-            case GGML_OP_MAP_CUSTOM1:
-            case GGML_OP_MAP_CUSTOM2:
-            case GGML_OP_MAP_CUSTOM3:
-            case GGML_OP_CUSTOM: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ true);
-            } break;
-            case GGML_OP_CROSS_ENTROPY_LOSS:
-            case GGML_OP_CROSS_ENTROPY_LOSS_BACK: {
-                split_state = handle_per_row(src_split_states);
-            } break;
-            case GGML_OP_OPT_STEP_ADAMW:
-            case GGML_OP_OPT_STEP_SGD:
-            case GGML_OP_GLU: {
-                split_state = handle_generic(src_split_states, /*scalar_only =*/ false);
-            } break;
-            default: {
-                GGML_ABORT("ggml op not implemented: %s", ggml_op_name(tensor->op));
-                split_state = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}};
-            } break;
-        }
-        if (split_state.axis >= 0 && split_state.axis < GGML_MAX_DIMS) {
-            bool src_split_by_axis_found = false;
-            const size_t n_bufs = ggml_backend_meta_buffer_n_bufs(tensor->buffer);
-
-            for (size_t i = 0; i < GGML_MAX_SRC; i++) {
-                if (tensor->src[i] == nullptr || src_split_states[i].axis < 0 || src_split_states[i].axis >= GGML_MAX_DIMS) {
-                    continue;
-                }
-                if (src_split_by_axis_found) {
-                    for (size_t j = 0; j < n_bufs; j++) {
-                        // Assert that ratio is consistent:
-                        GGML_ASSERT(   split_state.ne[j] * tensor->src[i]->ne[src_split_states[i].axis]
-                            == src_split_states[i].ne[j] *         tensor->ne[split_state.axis]);
-                    }
-                } else {
-                    for (size_t j = 0; j < n_bufs; j++) {
-                        // Take over ratio from src:
-                        split_state.ne[j] = src_split_states[i].ne[j] * tensor->ne[split_state.axis];
-                        GGML_ASSERT(split_state.ne[j] % tensor->src[i]->ne[src_split_states[i].axis] == 0);
-                        split_state.ne[j] /= tensor->src[i]->ne[src_split_states[i].axis];
-                    }
-                }
-                src_split_by_axis_found = true;
-            }
-            GGML_ASSERT(src_split_by_axis_found);
-        }
-        return split_state;
-    };
-
-    const std::pair key = std::make_pair(tensor, assume_sync);
-
-    if (buf_ctx->split_state_cache.find(key) == buf_ctx->split_state_cache.end()) {
-        buf_ctx->split_state_cache[key] = calculate_split_state();
-        if (buf_ctx->debug > 0) {
-            std::string srcs_info;
-            for (size_t i = 0; i < GGML_MAX_SRC; i++) {
-                if (tensor->src[i] == nullptr) {
-                    continue;
-                }
-                if (!srcs_info.empty()) {
-                    srcs_info += ", ";
-                }
-                const ggml_backend_meta_split_state split_state = ggml_backend_meta_get_split_state(tensor->src[0], true);
-                const char * axis_name = ggml_backend_meta_split_axis_name(split_state.axis);
-                std::string ne_info;
-                for (size_t j = 0; j < n_bufs; j++) {
-                    if (!ne_info.empty()) {
-                        ne_info += ", ";
-                    }
-                    ne_info += std::to_string(split_state.ne[j]);
-                }
-                srcs_info += std::string(tensor->src[i]->name) + "[" + ggml_op_name(tensor->src[i]->op) + ", " + axis_name + ", {" + ne_info + "}]";
-            }
-            std::string ne_info;
-            for (size_t j = 0; j < n_bufs; j++) {
-                if (!ne_info.empty()) {
-                    ne_info += ", ";
-                }
-                ne_info += std::to_string(buf_ctx->split_state_cache[key].ne[j]);
-            }
-            GGML_LOG_DEBUG("SPLIT_STATE: {%s} -> %s[%s, %s, {%s}]\n", srcs_info.c_str(), tensor->name, ggml_op_name(tensor->op),
-                ggml_backend_meta_split_axis_name(buf_ctx->split_state_cache[key].axis), ne_info.c_str());
-        }
-    }
-
-    ggml_backend_meta_split_state ret = buf_ctx->split_state_cache[key];
-    GGML_ASSERT(ret.axis != GGML_BACKEND_SPLIT_AXIS_NONE && ret.axis != GGML_BACKEND_SPLIT_AXIS_UNKNOWN);
-    return ret;
-}

--- a/ggml/src/ggml-ext.h
+++ b/ggml/src/ggml-ext.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "ggml.h"
+#include "ggml-backend.h"
+
+// This is a "staging" header for new ggml API
+// It is not publicly available and it should not be used by 3rd party projects
+//
+// When the API matures enough, it will be moved to the official public API
+
+//
+// Meta backend
+//
+
+#define GGML_BACKEND_META_MAX_DEVICES 16
+
+enum ggml_backend_meta_split_axis {
+    // tensor split by tensor dimensions:
+    GGML_BACKEND_SPLIT_AXIS_0   =  0,
+    GGML_BACKEND_SPLIT_AXIS_1   =  1,
+    GGML_BACKEND_SPLIT_AXIS_2   =  2,
+    GGML_BACKEND_SPLIT_AXIS_3   =  3,
+
+    GGML_BACKEND_SPLIT_AXIS_MIRRORED = 10, // all values on all backends
+    GGML_BACKEND_SPLIT_AXIS_PARTIAL  = 11, // each backend has a partial sum
+
+    // for internal bookkeeping only:
+    GGML_BACKEND_SPLIT_AXIS_NONE     = 98,
+    GGML_BACKEND_SPLIT_AXIS_UNKNOWN  = 99,
+};
+GGML_API const char * ggml_backend_meta_split_axis_name(enum ggml_backend_meta_split_axis split_axis);
+
+struct ggml_backend_meta_split_state {
+    enum ggml_backend_meta_split_axis axis;
+    int64_t                           ne[GGML_BACKEND_META_MAX_DEVICES];
+};
+
+// function to assign split states for statically allocated tensors, compute tensor split states will be assigned to be compatible:
+typedef struct ggml_backend_meta_split_state(*ggml_backend_meta_get_split_state_t)(const struct ggml_tensor * tensor, void * userdata);
+
+// create a new meta device from "simple" devices, meta buffer type/buffer/backend is then derived from this:
+// TODO: this looks a bit strange - a backend API creates a device. I think we should try
+//       express this as a backend registry functionality instead
+GGML_API ggml_backend_dev_t ggml_backend_meta_device(
+    ggml_backend_dev_t * devs, size_t n_devs, ggml_backend_meta_get_split_state_t get_split_state, void * get_split_state_ud);

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -215,10 +215,10 @@ llama_context::llama_context(
 
     if (!hparams.vocab_only) {
         // GPU backends
-        for (auto * dev : model.devices) {
-            ggml_backend_t backend = ggml_backend_dev_init(dev, nullptr);
+        for (const auto & dev : model.devices) {
+            ggml_backend_t backend = ggml_backend_dev_init(dev.dev, nullptr);
             if (backend == nullptr) {
-                throw std::runtime_error(format("failed to initialize %s backend", ggml_backend_dev_name(dev)));
+                throw std::runtime_error(format("failed to initialize %s backend", ggml_backend_dev_name(dev.dev)));
             }
             backends.emplace_back(backend);
         }
@@ -293,8 +293,8 @@ llama_context::llama_context(
 
             if (backend_type == GGML_BACKEND_DEVICE_TYPE_CPU && !model.devices.empty()) {
                 // use the host buffer of the first device CPU for faster transfer of the intermediate state
-                auto * dev = model.devices[0];
-                auto * host_buft = ggml_backend_dev_host_buffer_type(dev);
+                const auto & dev = model.devices[0];
+                auto * host_buft = ggml_backend_dev_host_buffer_type(dev.dev);
                 if (host_buft) {
                     buft = host_buft;
                 }
@@ -3392,7 +3392,7 @@ void llama_perf_context_reset(llama_context * ctx) {
 }
 
 void llama_memory_breakdown_print(const struct llama_context * ctx) {
-    const std::vector<ggml_backend_dev_t> & devices = ctx->get_model().devices;
+    const auto & devices = ctx->get_model().devices;
 
     std::map<ggml_backend_buffer_type_t, llama_memory_breakdown_data> memory_breakdown = ctx->memory_breakdown();
 
@@ -3428,7 +3428,7 @@ void llama_memory_breakdown_print(const struct llama_context * ctx) {
         if (dev) {
             int i_dev = -1;
             for (size_t i = 0; i < devices.size(); i++) {
-                if (devices[i] == dev) {
+                if (devices[i].dev == dev) {
                     i_dev = i;
                     break;
                 }
@@ -3445,7 +3445,7 @@ void llama_memory_breakdown_print(const struct llama_context * ctx) {
 
     // print memory breakdown for each device:
     for (size_t i = 0; i < devices.size(); i++) {
-        ggml_backend_dev_t          dev = devices[i];
+        ggml_backend_dev_t          dev = devices[i].dev;
         llama_memory_breakdown_data mb  = mb_dev[i];
 
         const std::string name = ggml_backend_dev_name(dev);

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -187,11 +187,7 @@ llama_kv_cache::llama_kv_cache(
                 t->buffer = buf; // set dummy buffer for KV cache so that the backend scheduler won't try to allocate it
             }
         } else {
-            if (ggml_backend_buft_is_meta(buft)) {
-                buf = ggml_backend_meta_alloc_ctx_tensors_from_buft(ctx.get(), buft);
-            } else {
-                buf = ggml_backend_alloc_ctx_tensors_from_buft(ctx.get(), buft); // real buffer
-            }
+            buf = ggml_backend_alloc_ctx_tensors_from_buft(ctx.get(), buft); // real buffer
         }
         if (!buf) {
             throw std::runtime_error("failed to allocate buffer for kv cache");

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -102,8 +102,7 @@ llama_memory_recurrent::llama_memory_recurrent(
 
     // allocate tensors and initialize the buffers to avoid NaNs in the padding
     for (auto & [buft, ctx] : ctx_map) {
-        ggml_backend_buffer_t buf = ggml_backend_buft_is_meta(buft) ?
-            ggml_backend_meta_alloc_ctx_tensors_from_buft(ctx.get(), buft) : ggml_backend_alloc_ctx_tensors_from_buft(ctx.get(), buft);
+        ggml_backend_buffer_t buf = ggml_backend_alloc_ctx_tensors_from_buft(ctx.get(), buft);
         if (!buf) {
             throw std::runtime_error("failed to allocate buffer for rs cache");
         }

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -366,7 +366,7 @@ static llama_rope_scaling_type llama_rope_scaling_type_from_string(const std::st
 }
 
 // CPU: ACCEL -> GPU host -> CPU extra -> CPU
-static buft_list_t make_cpu_buft_list(const std::vector<ggml_backend_dev_t> & devices, bool use_extra_bufts, bool no_host) {
+static buft_list_t make_cpu_buft_list(const std::vector<llama_device> & devices, bool use_extra_bufts, bool no_host) {
     buft_list_t buft_list;
 
     // add ACCEL buffer types
@@ -388,10 +388,10 @@ static buft_list_t make_cpu_buft_list(const std::vector<ggml_backend_dev_t> & de
     // a better approach would be to handle this on a weight-by-weight basis using the offload_op
     // function of the device to determine if it would benefit from being stored in a host buffer
     if (!no_host) {
-        for (auto * dev : devices) {
-            ggml_backend_buffer_type_t buft = ggml_backend_dev_host_buffer_type(dev);
+        for (const auto & dev : devices) {
+            ggml_backend_buffer_type_t buft = ggml_backend_dev_host_buffer_type(dev.dev);
             if (buft) {
-                buft_list.emplace_back(dev, buft);
+                buft_list.emplace_back(dev.dev, buft);
                 break;
             }
         }
@@ -529,7 +529,7 @@ void llama_model::load_arch(llama_model_loader & ml) {
     if (arch == LLM_ARCH_UNKNOWN) {
         throw std::runtime_error("unknown model architecture: '" + ml.get_arch_name() + "'");
     }
-    if (!devices.empty() && ggml_backend_dev_is_meta(devices[0]) && !llm_arch_supports_sm_tensor(arch)) {
+    if (!devices.empty() && devices[0].is_meta && !llm_arch_supports_sm_tensor(arch)) {
         throw std::runtime_error(std::string("LLAMA_SPLIT_MODE_TENSOR not implemented for architecture '") + llm_arch_name(arch) + "'");
     }
 }
@@ -2765,11 +2765,11 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
 
     // build a list of buffer types for the CPU and GPU devices
     pimpl->cpu_buft_list = make_cpu_buft_list(devices, params.use_extra_bufts, params.no_host);
-    for (auto * dev : devices) {
-        buft_list_t buft_list = make_gpu_buft_list(dev, split_mode, tensor_split);
+    for (const auto & dev : devices) {
+        buft_list_t buft_list = make_gpu_buft_list(dev.dev, split_mode, tensor_split);
         // add CPU buffer types as a fallback
         buft_list.insert(buft_list.end(), pimpl->cpu_buft_list.begin(), pimpl->cpu_buft_list.end());
-        pimpl->gpu_buft_list.emplace(dev, std::move(buft_list));
+        pimpl->gpu_buft_list.emplace(dev.dev, std::move(buft_list));
     }
 
     ggml_backend_dev_t cpu_dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
@@ -2783,7 +2783,7 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
     if (all_zero) {
         // default split, by free memory
         for (size_t i = 0; i < n_devices(); ++i) {
-            ggml_backend_dev_t dev = devices[i];
+            ggml_backend_dev_t dev = devices[i].dev;
             size_t total;
             size_t free;
             ggml_backend_dev_memory(dev, &free, &total);
@@ -2819,7 +2819,7 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
             return {cpu_dev, &pimpl->cpu_buft_list};
         }
         const int layer_gpu = std::upper_bound(splits.begin(), splits.begin() + n_devices(), float(il - i_gpu_start)/act_gpu_layers) - splits.begin();
-        auto * dev = devices.at(layer_gpu);
+        auto * dev = devices.at(layer_gpu).dev;
         LLAMA_LOG_DEBUG("load_tensors: layer %3d assigned to device %s, is_swa = %d\n", il, ggml_backend_dev_name(dev), is_swa);
         return {dev, &pimpl->gpu_buft_list.at(dev)};
     };

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1,6 +1,5 @@
 #include "llama-model.h"
 
-#include "ggml.h"
 #include "llama-arch.h"
 #include "llama-impl.h"
 #include "llama-mmap.h"
@@ -13,9 +12,13 @@
 #include "llama-memory-hybrid-iswa.h"
 #include "llama-memory-recurrent.h"
 
+#include "models/models.h"
+
+#include "ggml.h"
 #include "ggml-cpp.h"
 
-#include "models/models.h"
+// TODO: tmp until the ggml meta backend matures and becomes public
+#include "../src/ggml-ext.h"
 
 #include <algorithm>
 #include <cassert>

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -7693,11 +7693,7 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                     t->buffer = buf; // set dummy buffer for weights so that the backend scheduler won't try to allocate them
                 }
             } else {
-                if (ggml_backend_buft_is_meta(buft)) {
-                    buf = ggml_backend_meta_alloc_ctx_tensors_from_buft(ctx, buft); // real buffer
-                } else {
-                    buf = ggml_backend_alloc_ctx_tensors_from_buft(ctx, buft); // real buffer
-                }
+                buf = ggml_backend_alloc_ctx_tensors_from_buft(ctx, buft); // real buffer
             }
             if (buf == nullptr) {
                 throw std::runtime_error(format("unable to allocate %s buffer", ggml_backend_buft_name(buft)));

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -452,6 +452,12 @@ struct llama_layer {
     struct llama_layer_nextn nextn;
 };
 
+struct llama_device {
+    bool is_meta;
+
+    ggml_backend_dev_t dev;
+};
+
 struct llama_meta_device_get_split_state_userdata {
     size_t                     n_devices;
     const struct llama_model * model;
@@ -513,7 +519,7 @@ struct llama_model {
     std::unordered_map<std::string, std::string> gguf_kv;
 
     // list of devices used in this model
-    std::vector<ggml_backend_dev_t> devices;
+    std::vector<llama_device> devices;
 
     // for quantize-stats only
     std::vector<std::pair<std::string, struct ggml_tensor *>> tensors_by_name;

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -23,7 +23,6 @@
 #include <cstdio>
 #include <cstring>
 #include <ctime>
-#include <regex>
 #include <stdexcept>
 #include <vector>
 

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1002,7 +1002,6 @@ static struct llama_model * llama_model_load_from_file_impl(
                         break;
                     case GGML_BACKEND_DEVICE_TYPE_META:
                         GGML_ABORT("fatal error");
-                        break;
                 }
             }
         }

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1,6 +1,5 @@
 #include "llama.h"
 
-#include "ggml-cpp.h"
 #include "llama-impl.h"
 
 #include "llama-chat.h"
@@ -12,8 +11,12 @@
 #include "llama-model.h"
 
 #include "ggml.h"
+#include "ggml-cpp.h"
 #include "ggml-backend.h"
 #include "gguf.h"
+
+// TODO: tmp until the ggml meta backend matures and becomes public
+#include "../src/ggml-ext.h"
 
 #include <algorithm>
 #include <cassert>

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -55,7 +55,7 @@ struct llama_device_memory_data {
 
 static std::vector<llama_device_memory_data> llama_get_device_memory_data(
         const char * path_model, const llama_model_params * mparams, const llama_context_params * cparams,
-        std::vector<ggml_backend_dev_t> & devs, uint32_t & hp_ngl, uint32_t & hp_n_ctx_train, uint32_t & hp_n_expert,
+        std::vector<llama_device> & devs, uint32_t & hp_ngl, uint32_t & hp_n_ctx_train, uint32_t & hp_n_expert,
         const ggml_log_level log_level) {
     struct user_data_t {
         struct {
@@ -106,7 +106,7 @@ static std::vector<llama_device_memory_data> llama_get_device_memory_data(
             continue;
         }
         for (size_t i = 0; i < ret.size(); i++) {
-            if (model->devices[i] == dev) {
+            if (model->devices[i].dev == dev) {
                 ret[i].mb.model   += mb.model;
                 ret[i].mb.context += mb.context;
                 ret[i].mb.compute += mb.compute;
@@ -117,7 +117,7 @@ static std::vector<llama_device_memory_data> llama_get_device_memory_data(
     for (size_t i = 0; i < ret.size(); i++) {
         size_t free;
         size_t total;
-        ggml_backend_dev_memory(model->devices[i], &free, &total);
+        ggml_backend_dev_memory(model->devices[i].dev, &free, &total);
 
         // devices can return 0 bytes for free and total memory if they do not
         // have any to report. in this case, we will use the host memory as a fallback
@@ -171,7 +171,7 @@ static void llama_params_fit_impl(
     typedef std::vector<llama_device_memory_data> dmds_t;
     const llama_model_params default_mparams = llama_model_default_params();
 
-    std::vector<ggml_backend_dev_t> devs;
+    std::vector<llama_device> devs;
     uint32_t hp_ngl = 0; // hparams.n_gpu_layers
     uint32_t hp_nct = 0; // hparams.n_ctx_train
     uint32_t hp_nex = 0; // hparams.n_expert
@@ -196,10 +196,10 @@ static void llama_params_fit_impl(
     {
         dev_names.reserve(nd);
         size_t max_length = 0;
-        for (ggml_backend_dev_t dev : devs) {
-            std::string name = ggml_backend_dev_name(dev);
+        for (const llama_device & dev : devs) {
+            std::string name = ggml_backend_dev_name(dev.dev);
             name += " (";
-            name += ggml_backend_dev_description(dev);
+            name += ggml_backend_dev_description(dev.dev);
             name += ")";
             dev_names.push_back(name);
             max_length = std::max(max_length, name.length());
@@ -690,7 +690,7 @@ static void llama_params_fit_impl(
             ngl_per_device_test[id].overflow_type = LAYER_FRACTION_UP;
             std::vector<ggml_backend_buffer_type_t> overflow_bufts_test = overflow_bufts;
             if (id < nd - 1) {
-                overflow_bufts_test[id] = ggml_backend_dev_buffer_type(devs[id + 1]);
+                overflow_bufts_test[id] = ggml_backend_dev_buffer_type(devs[id + 1].dev);
             }
             LLAMA_LOG_DEBUG("%s: trying to fit one extra layer with overflow_type=LAYER_FRACTION_UP\n", __func__);
             std::vector<int64_t> mem_test = get_memory_for_layers(__func__, ngl_per_device_test, overflow_bufts_test);
@@ -931,20 +931,22 @@ static struct llama_model * llama_model_load_from_file_impl(
             }
             model->get_split_state_ud.n_devices = n_devs;
             model->get_split_state_ud.model = model;
-            model->devices.push_back(ggml_backend_meta_device(
-                params.devices, n_devs, llama_meta_device_get_split_state, &model->get_split_state_ud));
+            model->devices.push_back({
+                true, ggml_backend_meta_device(
+                params.devices, n_devs, llama_meta_device_get_split_state, &model->get_split_state_ud)
+            });
         } else {
             for (ggml_backend_dev_t * dev = params.devices; *dev; ++dev) {
-                model->devices.push_back(*dev);
+                model->devices.push_back({false, *dev});
             }
         }
     } else {
         // default device selection
 
         // build list of available devices
-        std::vector<ggml_backend_dev_t> gpus;
-        std::vector<ggml_backend_dev_t> igpus;
-        std::vector<ggml_backend_dev_t> rpc_servers;
+        std::vector<llama_device> gpus;
+        std::vector<llama_device> igpus;
+        std::vector<llama_device> rpc_servers;
 
         if (params.split_mode == LLAMA_SPLIT_MODE_TENSOR) {
             std::vector<ggml_backend_dev_t> devs;
@@ -956,8 +958,10 @@ static struct llama_model * llama_model_load_from_file_impl(
             GGML_ASSERT(ggml_backend_dev_buffer_type(devs.back()) == ggml_backend_cpu_buffer_type());
             model->get_split_state_ud.n_devices = devs.size() - 1;
             model->get_split_state_ud.model     = model;
-            gpus.push_back(ggml_backend_meta_device(
-                devs.data(), devs.size() - 1, llama_meta_device_get_split_state, &model->get_split_state_ud));
+            gpus.push_back({
+                true, ggml_backend_meta_device(
+                devs.data(), devs.size() - 1, llama_meta_device_get_split_state, &model->get_split_state_ud)
+            });
         } else {
             for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
                 ggml_backend_dev_t dev = ggml_backend_dev_get(i);
@@ -970,14 +974,14 @@ static struct llama_model * llama_model_load_from_file_impl(
                     case GGML_BACKEND_DEVICE_TYPE_GPU: {
                         ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
                         if (ggml_backend_reg_name(reg) == std::string("RPC")) {
-                            rpc_servers.push_back(dev);
+                            rpc_servers.push_back({false, dev});
                         } else {
                             // check if there is already a GPU with the same device id
                             ggml_backend_dev_props props;
                             ggml_backend_dev_get_props(dev, &props);
-                            auto it = std::find_if(gpus.begin(), gpus.end(), [&props](ggml_backend_dev_t d) {
+                            auto it = std::find_if(gpus.begin(), gpus.end(), [&props](const llama_device & d) {
                                 ggml_backend_dev_props d_props;
-                                ggml_backend_dev_get_props(d, &d_props);
+                                ggml_backend_dev_get_props(d.dev, &d_props);
                                 if (props.device_id && d_props.device_id) {
                                     return strcmp(props.device_id, d_props.device_id) == 0;
                                 }
@@ -989,16 +993,16 @@ static struct llama_model * llama_model_load_from_file_impl(
                                         __func__,
                                         ggml_backend_dev_name(dev), ggml_backend_dev_description(dev),
                                         props.device_id ? props.device_id : "unknown id",
-                                        ggml_backend_dev_name(*it), ggml_backend_dev_description(*it));
+                                        ggml_backend_dev_name(it->dev), ggml_backend_dev_description(it->dev));
                             } else {
-                                gpus.push_back(dev);
+                                gpus.push_back({false, dev});
                             }
                         }
                         break;
                     }
 
                     case GGML_BACKEND_DEVICE_TYPE_IGPU:
-                        igpus.push_back(dev);
+                        igpus.push_back({false, dev});
                         break;
                     case GGML_BACKEND_DEVICE_TYPE_META:
                         GGML_ABORT("fatal error");
@@ -1028,17 +1032,17 @@ static struct llama_model * llama_model_load_from_file_impl(
                 llama_model_free(model);
                 return nullptr;
             }
-            ggml_backend_dev_t main_gpu = model->devices[params.main_gpu];
+            llama_device main_gpu = model->devices[params.main_gpu];
             model->devices.clear();
             model->devices.push_back(main_gpu);
         }
     }
 
-    for (auto * dev : model->devices) {
+    for (const auto & dev : model->devices) {
         ggml_backend_dev_props props;
-        ggml_backend_dev_get_props(dev, &props);
+        ggml_backend_dev_get_props(dev.dev, &props);
         LLAMA_LOG_INFO("%s: using device %s (%s) (%s) - %zu MiB free\n", __func__,
-                ggml_backend_dev_name(dev), ggml_backend_dev_description(dev),
+                ggml_backend_dev_name(dev.dev), ggml_backend_dev_description(dev.dev),
                 props.device_id ? props.device_id : "unknown id",
                 props.memory_free/1024/1024);
     }

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -6,6 +6,8 @@
 #include "ggml-cpp.h"
 #include "llama.h"
 #include "llama-cpp.h"
+
+// TODO: replace with #include "llama-ext.h" in the future
 #include "../src/llama-arch.h"
 #include "../src/llama-model-saver.h"
 


### PR DESCRIPTION
review of https://github.com/ggml-org/llama.cpp/pull/19378

- Fixed compile warnings
- Moved most of the meta backend API to `ggml-backend-impl.h`
- `ggml_backend_meta_alloc_ctx_tensors_from_buft()` is now called from within `ggml_backend_alloc_ctx_tensors_from_buft()`
- Minimize the public and impl API of the meta backend
- Avoid introducing `ggml_backend_dev_is_meta()` by keeping this information in the `llama_model`
- Introduce new `ggml-ext.h` private header, used for staging new ggml APIs
- Move the Meta backend API to `ggml-ext.h`. The idea here is that we expect some volatility of the API which would make ggml versioning difficult and will impact the incoming package distributions. By encapsulating the API, we can iterate over it without worrying about backwards incompatibility. Once we are happy with the API, it will be moved to the public API (i.e. `ggml-backend.h`).

### TODOs:

- [ ] backend sampling currently fails:
  ```bash
  ./bin/llama-parallel -hf ggml-org/Qwen2.5-Coder-7B-Q8_0-GGUF -np 8 -ns 32 -s 1 -c 16384 -sm tensor -bs

  llama.cpp/ggml/src/ggml-backend-meta.cpp:1262: GGML_ASSERT(homogeneous_src_split_state.axis != GGML_BACKEND_SPLIT_AXIS_UNKNOWN) failed
  ```