### PR TITLE
llama : more robust logic for determining Meta devices

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -983,7 +983,7 @@ static struct llama_model * llama_model_load_from_file_impl(
                 LLAMA_LOG_INFO("%s: - device %zu: %s (%s)\n", __func__, i, ggml_backend_dev_name(devs[i]), ggml_backend_dev_description(devs[i]));
             }
 
-            GGML_ASSERT(devs.size() >= 2);
+            GGML_ASSERT(!devs.empty());
             model->get_split_state_ud.n_devices = devs.size();
             model->get_split_state_ud.model     = model;
             gpus.push_back({

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -972,7 +972,7 @@ static struct llama_model * llama_model_load_from_file_impl(
             for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
                 auto * dev = ggml_backend_dev_get(i);
                 if (ggml_backend_dev_buffer_type(dev) == ggml_backend_cpu_buffer_type()) {
-                    LLAMA_LOG_WARN("%s: skipping %s (%s) for tensor parallelism\n", __func__, ggml_backend_dev_name(dev), ggml_backend_dev_description(dev));
+                    LLAMA_LOG_INFO("%s: skipping %s (%s) for tensor parallelism\n", __func__, ggml_backend_dev_name(dev), ggml_backend_dev_description(dev));
                     continue;
                 }
                 devs.push_back(dev);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -970,15 +970,25 @@ static struct llama_model * llama_model_load_from_file_impl(
             std::vector<ggml_backend_dev_t> devs;
             devs.reserve(ggml_backend_dev_count());
             for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
-                devs.push_back(ggml_backend_dev_get(i));
+                auto * dev = ggml_backend_dev_get(i);
+                if (ggml_backend_dev_buffer_type(dev) == ggml_backend_cpu_buffer_type()) {
+                    LLAMA_LOG_WARN("%s: skipping %s (%s) for tensor parallelism\n", __func__, ggml_backend_dev_name(dev), ggml_backend_dev_description(dev));
+                    continue;
+                }
+                devs.push_back(dev);
             }
+
+            LLAMA_LOG_INFO("%s: creating a Meta device for tensor parallelism from %zu devices:\n", __func__, devs.size());
+            for (size_t i = 0; i < devs.size(); ++i) {
+                LLAMA_LOG_INFO("%s: - device %zu: %s (%s)\n", __func__, i, ggml_backend_dev_name(devs[i]), ggml_backend_dev_description(devs[i]));
+            }
+
             GGML_ASSERT(devs.size() >= 2);
-            GGML_ASSERT(ggml_backend_dev_buffer_type(devs.back()) == ggml_backend_cpu_buffer_type());
-            model->get_split_state_ud.n_devices = devs.size() - 1;
+            model->get_split_state_ud.n_devices = devs.size();
             model->get_split_state_ud.model     = model;
             gpus.push_back({
                 true, ggml_backend_meta_device(
-                devs.data(), devs.size() - 1, llama_meta_device_get_split_state, &model->get_split_state_ud)
+                devs.data(), devs.size(), llama_meta_device_get_split_state, &model->get_split_state_ud)
             });
         } else {
             for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {


### PR DESCRIPTION
With this patch, we can combine RPC devices into the Meta device to achieve tensor parallelism over the network. Also print some info about the constructed Meta device:

Sample output after the change:

```
0.00.006.276 W llama_model_load_from_file_impl: skipping BLAS (Accelerate) for tensor parallelism
0.00.006.279 W llama_model_load_from_file_impl: skipping CPU (Apple M2 Ultra) for tensor parallelism
0.00.007.490 I llama_model_load_from_file_impl: creating a Meta device for tensor parallelism from 4 devices:
0.00.007.492 I llama_model_load_from_file_impl: - device 0: MTL0 (Apple M2 Ultra)
0.00.007.493 I llama_model_load_from_file_impl: - device 1: MTL1 (Apple M2 Ultra)
0.00.007.493 I llama_model_load_from_file_impl: - device 2: RPC0 (127.0.0.1:50052)
0.00.007.493 I llama_model_load_from_file_impl: - device 3: RPC1 (127.0.0.1:50053)
```

